### PR TITLE
Descripción de main.tf

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -1,27 +1,30 @@
 terraform {
   required_providers {
     docker = {
-      source  = "kreuzwerker/docker"
-      version = "3.6.2"
+      source  = "kreuzwerker/docker"  # Se indica que se usará el proveedor "docker"
+      version = "3.6.2"               # Versión específica del proveedor
     }
   }
 }
 
 provider "docker" {
   # Configuración por defecto, asume Docker local
+  # Por omisión, se conecta al Docker local (unix socket)
+
 }
 
 resource "docker_container" "web_server" {
-  name  = "redis"
-  image = "redis:8.2.0-bookworm"
+  name  = "redis"                     # Nombre del contenedor Docker
+  image = "redis:8.2.0-bookworm"      # Imagen utilizada (Redis versión 8.2.0)
 
   ports {
-    internal = 6379
-    external = 32768
+    internal = 6379                   # Puerto interno que usa Redis por defecto
+    external = 32768                  # Puerto externo mapeado en el host
   }
 }
 
 output "redis_host_port" {
   description = "Puerto externo asignado automáticamente por Docker"
   value       = docker_container.web_server.ports[0].external
+  # Exporta el puerto externo, útil para conectarse al servicio desde fuera
 }


### PR DESCRIPTION
Se agregaron comentarios en el archivo principal de Terraform para explicar:
- La configuración del proveedor Docker.
- El recurso docker_container que despliega Redis.
- El bloque output que exporta el puerto externo. Esto facilita la comprensión del código para futuros desarrolladores.