### PR TITLE
añadir comentario explicativo en variable nginx_external_port

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -1,3 +1,3 @@
 variable "nginx_external_port" {
-  description = "Coloca el puerto de NGINX"
+  description = "Coloca el puerto de NGINX"  # Variable que define el puerto externo usado por NGINX
 }


### PR DESCRIPTION
Se agregó un comentario en la definición de la variable `nginx_external_port`  para aclarar que corresponde al puerto externo utilizado por NGINX.