### PR TITLE
chore(terraform): definir puertos externos para Nginx por entorno

### DIFF
--- a/terraform.tfvars
+++ b/terraform.tfvars
@@ -1,7 +1,7 @@
 
-nginx_external_port = {
-  redis_host_port = 32768
-  dev  = 3000
-  qa   = 4000
-  prod = 81
+nginx_external_port = {              # Mapa que define los puertos externos para Nginx según el entorno (workspace)
+  redis_host_port = 32768            # (No relacionado con Nginx) Puerto externo expuesto por el contenedor Redis
+  dev  = 3000                        # Puerto asignado para el entorno de desarrollo
+  qa   = 4000                        # Puerto asignado para el entorno de pruebas (QA)
+  prod = 81                          # Puerto asignado para el entorno de producción
 }


### PR DESCRIPTION
Se agrega la variable nginx_external_port como un mapa que define el puerto externo a exponer para el contenedor Nginx, según el entorno activo (workspace). Esto permite desplegar el mismo contenedor con diferentes configuraciones de red por entorno (dev, qa, prod).

Además, se incluye redis_host_port con valor 32768, aunque se recomienda separarlo si no se relaciona directamente con Nginx.

Este cambio es esencial para configurar el mapeo correcto de puertos en entornos múltiples.